### PR TITLE
Fix the resulting build url on Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'de.felixschulze.gradle:gradle-hockeyapp-plugin:3.6.4'
+        classpath 'com.github.heetch:hockeyapp-plugin:3.6.5'
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.github.heetch:hockeyapp-plugin:3.6.5'
+        classpath 'com.github.heetch:hockeyapp-plugin:3.6.6'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.6.5-SNAPSHOT
+version=3.6.6-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.6.4-SNAPSHOT
+version=3.6.5-SNAPSHOT

--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
@@ -242,7 +242,7 @@ class HockeyAppUploadTask extends DefaultTask {
                 if (uploadResponse) {
                     logger.info("Upload information: Title: '" + uploadResponse.title?.toString() + "' Config url: '" + uploadResponse.config_url?.toString()) + "'";
                     logger.debug("Upload response: " + uploadResponse.toString())
-                    def jiraTaskResult = JiraTask.pasteBuildUrlToJiraCard(logger, httpClient, hockeyApp, uploadResponse.public_url?.toString(), uploadResponse.config_url?.toString())
+                    def jiraTaskResult = JiraTask.pasteBuildUrlToJiraCard(httpClient, hockeyApp, uploadResponse.public_url?.toString(), uploadResponse.config_url?.toString())
                     logger.lifecycle("Result: " + jiraTaskResult)
                 }
             }

--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
@@ -38,20 +38,16 @@ import org.apache.http.HttpStatus
 import org.apache.http.client.HttpClient
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpPost
-import org.apache.http.entity.ByteArrayEntity
 import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.entity.mime.content.StringBody
 import org.apache.http.impl.client.HttpClientBuilder
-import org.apache.http.protocol.HTTP
 import org.gradle.api.DefaultTask
 import org.gradle.api.Nullable
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
-
-import java.nio.charset.Charset
 
 /**
  * Upload task for plugin
@@ -246,37 +242,14 @@ class HockeyAppUploadTask extends DefaultTask {
                 if (uploadResponse) {
                     logger.info("Upload information: Title: '" + uploadResponse.title?.toString() + "' Config url: '" + uploadResponse.config_url?.toString()) + "'";
                     logger.debug("Upload response: " + uploadResponse.toString())
-                    logger.lifecycle("Application public url " + uploadResponse.public_url?.toString())
-                    pasteBuildUrlToJiraCard(httpClient, uploadResponse.public_url?.toString())
+                    def jiraTaskResult = JiraTask.pasteBuildUrlToJiraCard(logger, httpClient, hockeyApp, uploadResponse.public_url?.toString(), uploadResponse.config_url?.toString())
+                    logger.lifecycle("Result: " + jiraTaskResult)
                 }
             }
             if (hockeyApp.teamCityLog) {
                 println TeamCityStatusMessageHelper.buildProgressString(TeamCityProgressType.FINISH, "Application uploaded successfully.")
             }
             progressLogger.completed()
-        }
-    }
-
-    def void pasteBuildUrlToJiraCard(HttpClient httpClient, String hockeyAppBuildUrl) {
-
-        if (hockeyApp.jiraUrlTitle != null &&
-                hockeyApp.jiraRepoUrl != null && hockeyApp.jiraCard != null
-                && hockeyApp.jiraPassword != null && hockeyApp.jiraUsername != null) {
-            String credentials = hockeyApp.jiraUsername + ":" + hockeyApp.jiraPassword;
-            String data = '{"object": {"url":"' + hockeyAppBuildUrl + '", "title":"'+ hockeyApp.jiraUrlTitle +'"}}'
-
-            HttpPost httpPost = new HttpPost("https://${hockeyApp.jiraRepoUrl}/rest/api/2/issue/${hockeyApp.jiraCard}/remotelink")
-
-            String base64EncodedCredentials = credentials.bytes.encodeBase64().toString()
-            httpPost.setHeader("Authorization", "Basic " + base64EncodedCredentials);
-            httpPost.setHeader(HTTP.CONTENT_TYPE, "application/json");
-
-            httpPost.setEntity(new ByteArrayEntity(data.getBytes(Charset.forName("UTF-8"))))
-            HttpResponse response = httpClient.execute(httpPost);
-
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
-                logger.error("Error: " + response.getEntity().getContent())
-            }
         }
     }
 

--- a/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
@@ -15,28 +15,28 @@ public class JiraTask {
     static def String pasteBuildUrlToJiraCard(HttpClient httpClient, HockeyAppPluginExtension hockeyApp, String hockeyAppPublicUrl, String hockeyAppConfigUrl) {
         def buildNumberUrl = hockeyAppPublicUrl + extractBuildNumberPath(hockeyAppConfigUrl)
 
-        if (hockeyApp.jiraUrlTitle != null &&
-                hockeyApp.jiraRepoUrl != null && hockeyApp.jiraCard != null
-                && hockeyApp.jiraPassword != null && hockeyApp.jiraUsername != null) {
-            String credentials = hockeyApp.jiraUsername + ":" + hockeyApp.jiraPassword;
-            String data = '{"object": {"url":"' + buildNumberUrl + '", "title":"' + hockeyApp.jiraUrlTitle + '"}}'
-
-            HttpPost httpPost = new HttpPost("https://${hockeyApp.jiraRepoUrl}/rest/api/2/issue/${hockeyApp.jiraCard}/remotelink")
-
-            String base64EncodedCredentials = credentials.bytes.encodeBase64().toString()
-            httpPost.setHeader("Authorization", "Basic " + base64EncodedCredentials);
-            httpPost.setHeader(HTTP.CONTENT_TYPE, "application/json");
-
-            httpPost.setEntity(new ByteArrayEntity(data.getBytes(Charset.forName("UTF-8"))))
-            HttpResponse response = httpClient.execute(httpPost);
-
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
-                return "Error " + response.getEntity().getContent()
-            } else {
-                return "Success, build url " + buildNumberUrl
-            }
+        if (hockeyApp.jiraUrlTitle == null || hockeyApp.jiraRepoUrl == null ||
+                hockeyApp.jiraCard == null || hockeyApp.jiraPassword == null || hockeyApp.jiraUsername == null) {
+            return null
         }
-        return null
+
+        String credentials = hockeyApp.jiraUsername + ":" + hockeyApp.jiraPassword;
+        String data = '{"object": {"url":"' + buildNumberUrl + '", "title":"' + hockeyApp.jiraUrlTitle + '"}}'
+
+        HttpPost httpPost = new HttpPost("https://${hockeyApp.jiraRepoUrl}/rest/api/2/issue/${hockeyApp.jiraCard}/remotelink")
+
+        String base64EncodedCredentials = credentials.bytes.encodeBase64().toString()
+        httpPost.setHeader("Authorization", "Basic " + base64EncodedCredentials);
+        httpPost.setHeader(HTTP.CONTENT_TYPE, "application/json");
+
+        httpPost.setEntity(new ByteArrayEntity(data.getBytes(Charset.forName("UTF-8"))))
+        HttpResponse response = httpClient.execute(httpPost);
+
+        if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+            return "Error " + response.getEntity().getContent()
+        }
+
+        return "Success, build url " + buildNumberUrl
     }
 
     // It sucks but that's the only place in the hockeyapp payload where the build number is given

--- a/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
@@ -1,0 +1,49 @@
+
+package de.felixschulze.gradle
+
+import org.apache.http.HttpResponse
+import org.apache.http.HttpStatus
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.ByteArrayEntity
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.protocol.HTTP
+import org.apache.tools.ant.taskdefs.condition.Http
+import org.apache.http.client.HttpClient
+
+import java.nio.charset.Charset
+
+public class JiraTask {
+
+    static def String pasteBuildUrlToJiraCard(HttpClient httpClient, HockeyAppPluginExtension hockeyApp, String hockeyAppPublicUrl, String hockeyAppConfigUrl) {
+        def buildNumberUrl = hockeyAppPublicUrl + extractBuildNumberPath(hockeyAppConfigUrl)
+
+        if (hockeyApp.jiraUrlTitle != null &&
+                hockeyApp.jiraRepoUrl != null && hockeyApp.jiraCard != null
+                && hockeyApp.jiraPassword != null && hockeyApp.jiraUsername != null) {
+            String credentials = hockeyApp.jiraUsername + ":" + hockeyApp.jiraPassword;
+            String data = '{"object": {"url":"' + buildNumberUrl + '", "title":"' + hockeyApp.jiraUrlTitle + '"}}'
+
+            HttpPost httpPost = new HttpPost("https://${hockeyApp.jiraRepoUrl}/rest/api/2/issue/${hockeyApp.jiraCard}/remotelink")
+
+            String base64EncodedCredentials = credentials.bytes.encodeBase64().toString()
+            httpPost.setHeader("Authorization", "Basic " + base64EncodedCredentials);
+            httpPost.setHeader(HTTP.CONTENT_TYPE, "application/json");
+
+            httpPost.setEntity(new ByteArrayEntity(data.getBytes(Charset.forName("UTF-8"))))
+            HttpResponse response = httpClient.execute(httpPost);
+
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+                return "Error " + response.getEntity().getContent()
+            } else {
+                return "Success, build url " + buildNumberUrl
+            }
+        }
+        return null
+    }
+
+    // It sucks but that's the only place in the hockeyapp payload where the build number is given
+    def static String extractBuildNumberPath(String hockeyAppConfigUrl) {
+        return hockeyAppConfigUrl?.substring(hockeyAppConfigUrl?.lastIndexOf("/app_versions"), hockeyAppConfigUrl?.length())
+    }
+}

--- a/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/JiraTask.groovy
@@ -3,12 +3,9 @@ package de.felixschulze.gradle
 
 import org.apache.http.HttpResponse
 import org.apache.http.HttpStatus
-import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.ByteArrayEntity
-import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.protocol.HTTP
-import org.apache.tools.ant.taskdefs.condition.Http
 import org.apache.http.client.HttpClient
 
 import java.nio.charset.Charset


### PR DESCRIPTION
This build fixes the wrong url pasted on the Jira card. Previously the url of the latest build was pasted, now it paste the one associated with what was just uploaded
